### PR TITLE
add /etc/default/libvirt-bin generation for debian system.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class libvirt (
   $libvirt_service    = $::libvirt::params::libvirt_service,
   $virtinst_package   = $::libvirt::params::virtinst_package,
   $sysconfig          = $::libvirt::params::sysconfig,
+  $default            = $::libvirt::params::default,  
   # libvirtd.conf options
   $listen_tls         = undef,
   $listen_tcp         = undef,
@@ -101,6 +102,17 @@ class libvirt (
       group   => 'root',
       mode    => '0644',
       content => template("${module_name}/sysconfig/libvirtd.erb"),
+      notify  => Service['libvirtd'],
+    }
+  }
+
+  # Optional changes to the /etc/default file (on debian)
+  if $default != false {
+    file { '/etc/default/libvirt-bin':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template("${module_name}/default/libvirt-bin.erb"),
       notify  => Service['libvirtd'],
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,12 +10,14 @@ class libvirt::params {
       $libvirt_service = 'libvirtd'
       $virtinst_package = 'python-virtinst'
       $sysconfig = {}
+      $default = false
     }
     'Debian': {
       $libvirt_package = 'libvirt-bin'
       $libvirt_service = 'libvirt-bin'
       $virtinst_package = 'virtinst'
       $sysconfig = false
+      $default = {}
       # UNIX socket
       $unix_sock_group = 'libvirtd'
       $auth_unix_ro = 'none'

--- a/templates/default/libvirt-bin.erb
+++ b/templates/default/libvirt-bin.erb
@@ -1,0 +1,22 @@
+# Defaults for libvirt-bin initscript (/etc/init.d/libvirt-bin)
+# This is a POSIX shell fragment
+
+# Start libvirtd to handle qemu/kvm:
+
+<% if @default['start_libvirtd'] -%>
+start_libvirtd="<%= @default['start_libvirtd'] %>"
+<% else -%>
+start_libvirtd="yes"
+<% end -%>
+# options passed to libvirtd, add "-l" to listen on tcp
+
+<% if @default['libvirtd_opts'] -%>
+libvirtd_opts="<%= @default['libvirtd_opts'] %>"
+<% else -%>
+libvirtd_opts="-d"
+<% end -%>
+
+# pass in location of kerberos keytab
+<% if @default['KRB5_KTNAME'] -%>
+export KRB5_KTNAME=<%= @default['KRB5_KTNAME'] %>
+<% end -%>

--- a/templates/default/libvirt-bin.orig
+++ b/templates/default/libvirt-bin.orig
@@ -1,0 +1,11 @@
+# Defaults for libvirt-bin initscript (/etc/init.d/libvirt-bin)
+# This is a POSIX shell fragment
+
+# Start libvirtd to handle qemu/kvm:
+start_libvirtd="yes"
+
+# options passed to libvirtd, add "-l" to listen on tcp
+libvirtd_opts="-d --listen"
+
+# pass in location of kerberos keytab
+#export KRB5_KTNAME=/etc/libvirt/libvirt.keytab


### PR DESCRIPTION
This pull request allows puppet to generate the libvirt-bin default file used by the init script of libvirt daemon.
It's the equivalent of sysconfig for red hat ( I  guess ).

Example :

```
class { 'libvirt':
  virtinst           => false,
  listen_tcp         => true,
  listen_tls         => false,
  auth_tcp           => "none",
  tcp_port           => 16510,
  unix_sock_group    => "libvirt",
  default            => {
    "start_libvirtd" => "yes",
    "libvirtd_opts"  => "-d -l"
  }    
```

  }

Matt
