### PR TITLE
Added support for configuring Kerberos authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,27 @@ class { 'libvirt':
 }
 ```
 
+Configure Kerberos authentication:
+
+```puppet
+class { 'libvirt':
+ listen_tls                => false,
+ listen_tcp                => true,
+ auth_tcp                  => 'sasl',
+ sysconfig                 => {
+   'LIBVIRTD_ARGS' => '--listen',
+ },
+ sasl2_libvirt_mech_list   => 'gssapi',
+ sasl2_libvirt_keytab      => '/etc/libvirt/krb5.tab',
+ qemu_vnc_listen           => "0.0.0.0",
+ qemu_vnc_sasl             => true,
+ qemu_vnc_tls              => false,
+ sasl2_qemu_mech_list      => 'gssapi',
+ sasl2_qemu_keytab         => '/etc/qemu/krb5.tab',
+ sasl2_qemu_auxprop_plugin => 'sasldb',
+}
+```
+
 Replace the default network with a PXE boot one :
 
 ```puppet

--- a/templates/sasl2/libvirt.conf.erb
+++ b/templates/sasl2/libvirt.conf.erb
@@ -1,0 +1,36 @@
+# If you want to use the non-TLS socket, then you *must* include
+# the GSSAPI or DIGEST-MD5 mechanisms, because they are the only
+# ones that can offer session encryption as well as authentication.
+#
+# If you're only using TLS, then you can turn on any mechanisms
+# you like for authentication, because TLS provides the encryption
+#
+# Default to a simple username+password mechanism
+<% if @sasl2_libvirt_mech_list -%>
+mech_list: <%= @sasl2_libvirt_mech_list %>
+<% else -%>
+mech_list: digest-md5
+<% end -%>
+
+# Before you can use GSSAPI, you need a service principle on the
+# KDC server for libvirt, and that to be exported to the keytab
+# file listed below
+#mech_list: gssapi
+#
+# You can also list many mechanisms at once, then the user can choose
+# by adding  '?auth=sasl.gssapi' to their libvirt URI, eg
+#   qemu+tcp://hostname/system?auth=sasl.gssapi
+#mech_list: digest-md5 gssapi
+
+# MIT kerberos ignores this option & needs KRB5_KTNAME env var.
+# May be useful for other non-Linux OS though....
+<% if @sasl2_libvirt_keytab -%>
+keytab: <%= @sasl2_libvirt_keytab %>
+<% else -%>
+keytab: /etc/libvirt/krb5.tab
+<% end -%>
+
+# If using digest-md5 for username/passwds, then this is the file
+# containing the passwds. Use 'saslpasswd2 -a libvirt [username]'
+# to add entries, and 'sasldblistusers2 -a libvirt' to browse it
+sasldb_path: /etc/libvirt/passwd.db

--- a/templates/sasl2/libvirt.conf.orig
+++ b/templates/sasl2/libvirt.conf.orig
@@ -1,0 +1,29 @@
+# If you want to use the non-TLS socket, then you *must* include
+# the GSSAPI or DIGEST-MD5 mechanisms, because they are the only
+# ones that can offer session encryption as well as authentication.
+#
+# If you're only using TLS, then you can turn on any mechanisms
+# you like for authentication, because TLS provides the encryption
+#
+# Default to a simple username+password mechanism
+mech_list: digest-md5
+
+# Before you can use GSSAPI, you need a service principle on the
+# KDC server for libvirt, and that to be exported to the keytab
+# file listed below
+#mech_list: gssapi
+#
+# You can also list many mechanisms at once, then the user can choose
+# by adding  '?auth=sasl.gssapi' to their libvirt URI, eg
+#   qemu+tcp://hostname/system?auth=sasl.gssapi
+#mech_list: digest-md5 gssapi
+
+# MIT kerberos ignores this option & needs KRB5_KTNAME env var.
+# May be useful for other non-Linux OS though....
+keytab: /etc/libvirt/krb5.tab
+
+# If using digest-md5 for username/passwds, then this is the file
+# containing the passwds. Use 'saslpasswd2 -a libvirt [username]'
+# to add entries, and 'sasldblistusers2 -a libvirt' to browse it
+sasldb_path: /etc/libvirt/passwd.db
+

--- a/templates/sasl2/qemu-kvm.conf.erb
+++ b/templates/sasl2/qemu-kvm.conf.erb
@@ -1,0 +1,45 @@
+# If you want to use the non-TLS socket, then you *must* include
+# the GSSAPI or DIGEST-MD5 mechanisms, because they are the only
+# ones that can offer session encryption as well as authentication.
+#
+# If you're only using TLS, then you can turn on any mechanisms
+# you like for authentication, because TLS provides the encryption
+#
+# Default to a simple username+password mechanism
+# NB digest-md5 is no longer considered secure by current standards
+<% if @sasl2_qemu_mech_list -%>
+mech_list: <%= @sasl2_qemu_mech_list %>
+<% else -%>
+mech_list: digest-md5
+<% end -%>
+
+# Before you can use GSSAPI, you need a service principle on the
+# KDC server for libvirt, and that to be exported to the keytab
+# file listed below
+#mech_list: gssapi
+#
+# You can also list many mechanisms at once, then the user can choose
+# by adding  '?auth=sasl.gssapi' to their libvirt URI, eg
+#   qemu+tcp://hostname/system?auth=sasl.gssapi
+#mech_list: digest-md5 gssapi
+
+# Some older builds of MIT kerberos on Linux ignore this option &
+# instead need KRB5_KTNAME env var.
+# For modern Linux, and other OS, this should be sufficient
+<% if @sasl2_qemu_keytab -%>
+keytab: <%= @sasl2_qemu_keytab %>
+<% else -%>
+keytab: /etc/qemu/krb5.tab
+<% end -%>
+
+# If using digest-md5 for username/passwds, then this is the file
+# containing the passwds. Use 'saslpasswd2 -a qemu [username]'
+# to add entries, and 'sasldblistusers2 -a qemu' to browse it
+sasldb_path: /etc/qemu/passwd.db
+
+<% if @sasl2_qemu_auxprop_plugin -%>
+auxprop_plugin: <%= @sasl2_qemu_auxprop_plugin %>
+<% else -%>
+auxprop_plugin: sasldb
+<% end -%>
+

--- a/templates/sasl2/qemu-kvm.conf.orig
+++ b/templates/sasl2/qemu-kvm.conf.orig
@@ -1,0 +1,34 @@
+# If you want to use the non-TLS socket, then you *must* include
+# the GSSAPI or DIGEST-MD5 mechanisms, because they are the only
+# ones that can offer session encryption as well as authentication.
+#
+# If you're only using TLS, then you can turn on any mechanisms
+# you like for authentication, because TLS provides the encryption
+#
+# Default to a simple username+password mechanism
+# NB digest-md5 is no longer considered secure by current standards
+mech_list: digest-md5
+
+# Before you can use GSSAPI, you need a service principle on the
+# KDC server for libvirt, and that to be exported to the keytab
+# file listed below
+#mech_list: gssapi
+#
+# You can also list many mechanisms at once, then the user can choose
+# by adding  '?auth=sasl.gssapi' to their libvirt URI, eg
+#   qemu+tcp://hostname/system?auth=sasl.gssapi
+#mech_list: digest-md5 gssapi
+
+# Some older builds of MIT kerberos on Linux ignore this option &
+# instead need KRB5_KTNAME env var.
+# For modern Linux, and other OS, this should be sufficient
+keytab: /etc/qemu/krb5.tab
+
+# If using digest-md5 for username/passwds, then this is the file
+# containing the passwds. Use 'saslpasswd2 -a qemu [username]'
+# to add entries, and 'sasldblistusers2 -a qemu' to browse it
+sasldb_path: /etc/qemu/passwd.db
+
+
+auxprop_plugin: sasldb
+


### PR DESCRIPTION
This patch adds all the necessary bits to configure the `kerberos` authentication in `libvirt`. Details about how to configure it:
- http://www.freeipa.org/page/Libvirt_with_VNC_Consoles
- http://wiki.libvirt.org/page/Libvirt_daemon_is_not_listening_on_tcp_ports_although_configured_to

It adds two new files to the module:
- `/etc/sasl2/libvirt.conf` provided by `libvirt` package.
- `/etc/sasl2/qemu-kvm.conf` provided by `qemu-kvm` package.

It requires #18 (it'll be rebased when the previous one is merged).
It also requires tests to be included.
