### PR TITLE
fixed typo in init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,7 +54,7 @@ class libvirt (
   $qemu_set_process_name     = undef,
   # sasl2 options
   $sasl2_libvirt_mech_list   = undef,
-  $sasl2_libvirt_keytab      = undef
+  $sasl2_libvirt_keytab      = undef,
   $sasl2_qemu_mech_list      = undef,
   $sasl2_qemu_keytab         = undef,
   $sasl2_qemu_auxprop_plugin = undef,


### PR DESCRIPTION
Ran puppet parser and noticed that line 57 in init.pp was missing the trailing ','.  Fixed it. This is my first pull request, so if i messed something up let me know and I'll fix it. Thanks for the module.
