### PR TITLE
strip whitespace to fix pool detection

### DIFF
--- a/lib/puppet/provider/libvirt_pool/virsh.rb
+++ b/lib/puppet/provider/libvirt_pool/virsh.rb
@@ -27,8 +27,8 @@ Puppet::Type.type(:libvirt_pool).provide(:virsh) do
 
   def status
     list = virsh '-q', 'pool-list', '--all'
-    list.strip.split(/\n/)[0..-1].detect do |line|  
-      fields = line.split(/ +/)
+    list.split(/\n/)[0..-1].detect do |line|  
+      fields = line.strip.split(/ +/)
       if (fields[0].match(/^#{resource[:name]}$/))
         return :present
       end

--- a/lib/puppet/provider/libvirt_pool/virsh.rb
+++ b/lib/puppet/provider/libvirt_pool/virsh.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:libvirt_pool).provide(:virsh) do
     pools = []
     hash = {}
     list = virsh '-q', 'pool-list', '--all'
-    list.split(/\n/)[0..-1].map do |line|
+    list.strip.split(/\n/)[0..-1].map do |line|
       values = line.split(/ +/)
       hash = { 
         :name      => values[0],
@@ -27,7 +27,7 @@ Puppet::Type.type(:libvirt_pool).provide(:virsh) do
 
   def status
     list = virsh '-q', 'pool-list', '--all'
-    list.split(/\n/)[0..-1].detect do |line|  
+    list.strip.split(/\n/)[0..-1].detect do |line|  
       fields = line.split(/ +/)
       if (fields[0].match(/^#{resource[:name]}$/))
         return :present

--- a/lib/puppet/provider/libvirt_pool/virsh.rb
+++ b/lib/puppet/provider/libvirt_pool/virsh.rb
@@ -11,8 +11,8 @@ Puppet::Type.type(:libvirt_pool).provide(:virsh) do
     pools = []
     hash = {}
     list = virsh '-q', 'pool-list', '--all'
-    list.strip.split(/\n/)[0..-1].map do |line|
-      values = line.split(/ +/)
+    list.split(/\n/)[0..-1].map do |line|
+      values = line.strip.split(/ +/)
       hash = { 
         :name      => values[0],
         :active    => values[1].match(/^act/)? :true : :false,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,10 @@ class libvirt::params {
       $sysconfig = false
       $deb_default = {}
       # UNIX socket
-      $unix_sock_group = 'libvirtd'
+      $unix_sock_group = $::operatingsystem ? {
+	'Debian' => 'libvirt',
+	'Ubuntu' => 'libvirtd', 
+      },
       $auth_unix_ro = 'none'
       $unix_sock_rw_perms = '0770'
       $auth_unix_rw = 'none'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,20 +18,33 @@ class libvirt::params {
       $deb_default = false
     }
     'Debian': {
-      $libvirt_package = 'libvirt-bin'
-      $libvirt_service = 'libvirt-bin'
-      $virtinst_package = 'virtinst'
-      $radvd_package = 'radvd'
-      $sysconfig = false
-      $deb_default = {}
-      # UNIX socket
-      $unix_sock_group = $::operatingsystem ? {
-	'Debian' => 'libvirt',
-	'Ubuntu' => 'libvirtd', 
-      }
-      $auth_unix_ro = 'none'
-      $unix_sock_rw_perms = '0770'
-      $auth_unix_rw = 'none'
+      case $::operatingsystem {
+        'Debian': {
+          $libvirt_package = 'libvirt-bin'
+          $libvirt_service = 'libvirtd'
+          $virtinst_package = 'virtinst'
+          $radvd_package = 'radvd'
+          $sysconfig = false
+          $deb_default = {}
+          # UNIX socket
+          $unix_sock_group = 'libvirt',
+          $auth_unix_ro = 'none'
+          $unix_sock_rw_perms = '0770'
+          $auth_unix_rw = 'none'
+        }
+      'Ubuntu': {
+          $libvirt_package = 'libvirt-bin'
+          $libvirt_service = 'libvirt-bin'
+          $virtinst_package = 'virtinst'
+          $radvd_package = 'radvd'
+          $sysconfig = false
+          $deb_default = {}
+          # UNIX socket
+          $unix_sock_group = 'libvirtd',
+          $auth_unix_ro = 'none'
+          $unix_sock_rw_perms = '0770'
+          $auth_unix_rw = 'none'
+        }
     }
     default: {
       $libvirt_package = 'libvirt'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,7 +28,7 @@ class libvirt::params {
       $unix_sock_group = $::operatingsystem ? {
 	'Debian' => 'libvirt',
 	'Ubuntu' => 'libvirtd', 
-      },
+      }
       $auth_unix_ro = 'none'
       $unix_sock_rw_perms = '0770'
       $auth_unix_rw = 'none'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,6 +45,7 @@ class libvirt::params {
           $unix_sock_rw_perms = '0770'
           $auth_unix_rw = 'none'
         }
+      }
     }
     default: {
       $libvirt_package = 'libvirt'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,7 @@ class libvirt::params {
           $sysconfig = false
           $deb_default = {}
           # UNIX socket
-          $unix_sock_group = 'libvirt',
+          $unix_sock_group = 'libvirt'
           $auth_unix_ro = 'none'
           $unix_sock_rw_perms = '0770'
           $auth_unix_rw = 'none'
@@ -40,7 +40,7 @@ class libvirt::params {
           $sysconfig = false
           $deb_default = {}
           # UNIX socket
-          $unix_sock_group = 'libvirtd',
+          $unix_sock_group = 'libvirtd'
           $auth_unix_ro = 'none'
           $unix_sock_rw_perms = '0770'
           $auth_unix_rw = 'none'


### PR DESCRIPTION
The output of 'virsh pool-list' starts with a space so the regexp's values[0] is empty. This patch strips such whitespace.