### PR TITLE
remove general include of REXML

### DIFF
--- a/lib/puppet/provider/libvirt_pool/virsh.rb
+++ b/lib/puppet/provider/libvirt_pool/virsh.rb
@@ -1,8 +1,6 @@
 require 'rexml/document'
 require 'tempfile'
 
-include REXML
-
 Puppet::Type.type(:libvirt_pool).provide(:virsh) do
 
   commands :virsh => 'virsh' 
@@ -147,7 +145,7 @@ Puppet::Type.type(:libvirt_pool).provide(:virsh) do
   end
 
   def buildPoolXML(resource)
-    root = Document.new
+    root = REXML::Document.new
     # pool
     pool = root.add_element 'pool', {'type' => resource[:type]}
     # name


### PR DESCRIPTION
this fixes #31 where the provider fails on CentOS 6.5 (probably on older ruby versions in general)