### PR TITLE
Fix version comparison for puppet future parser

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class libvirt::params {
     'RedHat': {
       $libvirt_package = "libvirt.${::architecture}"
       $libvirt_service = 'libvirtd'
-      if $::operatingsystemmajrelease >= 7 {
+      if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
         $virtinst_package = 'virt-install'
       } else {
         $virtinst_package = 'python-virtinst'


### PR DESCRIPTION
Use the native versioncmp function in puppet for version comparisons.

This fixes an issue that cause the catalog to fail compilation in puppet 3.7.x with future parser and should
continue to work with older versions as well.

The error being fixed:
Puppet (err): Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Comparison of: #<Puppet::Pops::Model::ModelLabelProvider:0x0000000aadf570> >= Integer, is not possible. Caused by 'Only Strings and Numbers are comparable'. 
