### PR TITLE
Force language to English in virsh

### DIFF
--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -85,11 +85,12 @@ define libvirt::network (
   include ::libvirt::params
 
   Exec {
-    cwd      => '/',
-    path     => '/bin:/usr/bin',
-    user     => 'root',
-    provider => 'posix',
-    require  => Service[$::libvirt::params::libvirt_service],
+    cwd         => '/',
+    path        => '/bin:/usr/bin',
+    user        => 'root',
+    provider    => 'posix',
+    require     => Service[$::libvirt::params::libvirt_service],
+    environment => ['LC_ALL=en_US.utf8', ],
   }
 
   $ensure_file = $ensure? {


### PR DESCRIPTION
Set environment variable LC_ALL to 'en_US.utf8' in order to force virsh output in English. 
Starting at least from version 1.1.1 (CentOS/RHEL 7), virsh is (partially) internationalized.
 Example:
 
$ export LC_ALL=fr_FR.utf8
$ virsh -q net-list --all
br0 actif yes yes

$ export LC_ALL=en_US.utf8
$ virsh -q net-list --all
br0 active yes yes

It doesn't play well with various execs in this module, because unless or onlyif conditions 'greps' on "active".