### PR TITLE
Strip leading whitespace from virsh pool-list output.

### DIFF
--- a/lib/puppet/provider/libvirt_pool/virsh.rb
+++ b/lib/puppet/provider/libvirt_pool/virsh.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:libvirt_pool).provide(:virsh) do
     hash = {}
     list = virsh '-q', 'pool-list', '--all'
     list.split(/\n/)[0..-1].map do |line|
-      values = line.split(/ +/)
+      values = line.strip.split(/ +/)
       hash = { 
         :name      => values[0],
         :active    => values[1].match(/^act/)? :true : :false,
@@ -28,7 +28,7 @@ Puppet::Type.type(:libvirt_pool).provide(:virsh) do
   def status
     list = virsh '-q', 'pool-list', '--all'
     list.split(/\n/)[0..-1].detect do |line|  
-      fields = line.split(/ +/)
+      fields = line.strip.split(/ +/)
       if (fields[0].match(/^#{resource[:name]}$/))
         return :present
       end


### PR DESCRIPTION
Simple fix for virsh pool-list output. I don't know exactly which libvirt version this appeared in but here's the ref info if anyone is curious.
```
commit 96f4b5eb8c39ae57608118e0bfc04e77e1516956
Author: Peter Krempa <pkrempa@redhat.com>
Date:   Tue Nov 12 17:22:36 2013 +0100
```