### PR TITLE
Basic support for portgroups in network resource

### DIFF
--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -72,11 +72,13 @@ define libvirt::network (
   $autostart          = false,
   $bridge             = undef,
   $forward_mode       = undef,
+  $virtualport        = false,
   $forward_dev        = undef,
   $forward_interfaces = [],
   $ip                 = undef,
   $ipv6               = undef,
   $mac                = undef,
+  $portgroups         = {},
 ) {
   validate_bool ($autostart)
   validate_re ($ensure, '^(present|defined|enabled|running|undefined|absent)$',

--- a/templates/network.xml.erb
+++ b/templates/network.xml.erb
@@ -15,6 +15,22 @@
   <%- if @bridge -%>
   <bridge name='<%= @bridge -%>'<%- if @forward_mode and @forward_mode != 'bridge' -%> stp='on' delay='0'<%-end-%>/>
   <%- end -%>
+  <%- if @virtualport -%>
+  <virtualport type='openvswitch'/>
+  <%- end -%>
+  <%- if !@portgroups.empty? -%>
+  <%-   @portgroups.each do |n, pg| -%>
+  <portgroup name='<%= n -%>'<%- if pg.has_key?('default') -%> default='<%= pg.default -%>'<%- end -%> >
+    <%- if pg.has_key?('vlan') -%>
+    <vlan>
+      <%- [pg.vlan].flatten.each do |v| -%>
+      <tag id='<%= v -%>'/>
+      <%- end -%>
+    </vlan>
+    <%- end -%>
+  </portgroup>
+  <%-   end -%>
+  <%- end -%>
   <%-if @ip -%>
   <%-  @ip.each do |ip| -%>
   <ip<%-if ip['address']-%> address='<%=ip['address']-%>'<%-end-%><%-if ip['netmask']-%> netmask='<%=ip['netmask']-%>'<%-end-%><%-if ip['prefix']-%> prefix='<%=ip['prefix']-%>'<%-end-%><%- unless ip['dhcp'] %>/<%- end -%>>


### PR DESCRIPTION
Not a fan of passing in hashes but the alternative would be define libvirt::network::portgroup with concat fragments.
```puppet
$networks = {
  'net-vl-50' => {
    autostart => true,
    bridge    => 'br0',
    forward_mode => 'bridge',
    virtualport => true,
    portgroups => {
      'port-vl-50' => {
        'default' => 'yes',
        vlan => [
          '50',
        ],
      },
    },
  },
  'net-vl-56' => {
    autostart => true,
    bridge    => 'br0',
    forward_mode => 'bridge',
    virtualport => true,
    portgroups => {
      'port-vl-56' => {
        'default' => 'yes',
        vlan => [
          '56',
        ],
      },
    },
  },
}

create_resources('::libvirt::network', $networks)
```