### PR TITLE
Add mappings for x509 certificates

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,11 @@ class libvirt (
   $mdns_adv                  = undef,
   $auth_tcp                  = undef,
   $auth_tls                  = undef,
+  $key_file                  = undef,
+  $cert_file                 = undef,
+  $ca_file                   = undef,
+  $crl_file                  = undef,
+  $tls_allowed_dn_list       = undef,
   $unix_sock_group           = $::libvirt::params::unix_sock_group,
   $unix_sock_ro_perms        = $::libvirt::params::unix_sock_ro_perms,
   $auth_unix_ro              = $::libvirt::params::auth_unix_ro,
@@ -160,4 +165,3 @@ class libvirt (
   create_resources(libvirt::network, $networks, $networks_defaults)
 
 }
-

--- a/templates/libvirtd.conf.erb
+++ b/templates/libvirtd.conf.erb
@@ -211,20 +211,31 @@ auth_tls = "<%= @auth_tls %>"
 # Override the default server key file path
 #
 #key_file = "/etc/pki/libvirt/private/serverkey.pem"
+<% if @key_file -%>
+key_file = "<%= @key_file %>"
+<% end -%>
 
 # Override the default server certificate file path
 #
 #cert_file = "/etc/pki/libvirt/servercert.pem"
+<% if @cert_file -%>
+cert_file = "<%= @cert_file %>"
+<% end -%>
 
 # Override the default CA certificate path
 #
 #ca_file = "/etc/pki/CA/cacert.pem"
+<% if @ca_file -%>
+ca_file = "<%= @ca_file %>"
+<% end -%>
 
 # Specify a certificate revocation list.
 #
 # Defaults to not using a CRL, uncomment to enable it
 #crl_file = "/etc/pki/CA/crl.pem"
-
+<% if @crl_file -%>
+crl_file = "<%= @crl_file %>"
+<% end -%>
 
 
 #################################################################
@@ -265,7 +276,9 @@ auth_tls = "<%= @auth_tls %>"
 #
 # By default, no DN's are checked
 #tls_allowed_dn_list = ["DN1", "DN2"]
-
+<% if @tls_allowed_dn_list -%>
+tls_allowed_dn_list = <%= @tls_allowed_dn_list %>
+<% end -%>
 
 # A whitelist of allowed SASL usernames. The format for usernames
 # depends on the SASL authentication mechanism. Kerberos usernames


### PR DESCRIPTION
It would be useful to be able to change these when needed. Also, the CRL is not enabled by default and must be uncommented to use it, so I exposed that as well as the DN list.