### PR TITLE
Added new config capabilities for qemu

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,8 @@ class libvirt (
   $qemu_set_process_name     = undef,
   $qemu_user                 = undef,
   $qemu_group                = undef,
+  $qemu_cgroup_device_acl    = undef,
+  $qemu_clear_emulator_capabilities = undef,
   # sasl2 options
   $sasl2_libvirt_mech_list   = undef,
   $sasl2_libvirt_keytab      = undef,

--- a/templates/qemu.conf.erb
+++ b/templates/qemu.conf.erb
@@ -213,6 +213,9 @@ group = "<%= @qemu_group %>"
 #    "/dev/rtc", "/dev/hpet",
 #]
 
+<% if @qemu_cgroup_device_acl -%>
+cgroup_device_acl = [ "<%= @qemu_cgroup_device_acl.join('", "') %>" ]
+<% end -%>
 
 # The default format for Qemu/KVM guest save images is raw; that is, the
 # memory from the domain is dumped out directly to a file.  If you have
@@ -302,6 +305,9 @@ group = "<%= @qemu_group %>"
 #
 # clear_emulator_capabilities = 1
 
+<% if @qemu_clear_emulator_capabilities -%>
+clear_emulator_capabilities = <%= @qemu_clear_emulator_capabilities %>
+<% end -%>
 
 # If allow_disk_format_probing is enabled, libvirt will probe disk
 # images to attempt to identify their format, when not otherwise


### PR DESCRIPTION
The parameters cgroup_device_acl (array) and clear_emulator_capabilities are needed in order to deploy calico:
https://www.projectcalico.org/