### PR TITLE
honor settings in ::libvirt

### DIFF
--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -89,7 +89,7 @@ define libvirt::network (
     path        => '/bin:/usr/bin',
     user        => 'root',
     provider    => 'posix',
-    require     => Service[$::libvirt::params::libvirt_service],
+    require     => Service[$::libvirt::libvirt_service],
     environment => ['LC_ALL=en_US.utf8', ],
   }
 


### PR DESCRIPTION
If ::libvirt overwrites this setting it is ignored.