### PR TITLE
Allows systemd to track libvirtd without forking.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,10 @@ class libvirt::params {
       $virtinst_package = 'virtinst'
       $radvd_package = 'radvd'
       $sysconfig = false
-      $deb_default = {}
+      $deb_default = $::service_provider ? {
+        'systemd' => { 'libvirtd_opts' => '' },  # no '-d', it confuses systemd
+        default   => {},
+      }
       # UNIX socket
       $auth_unix_ro = 'none'
       $unix_sock_rw_perms = '0770'


### PR DESCRIPTION
On systems with services managed by systemd, e.g. Ubuntu 16.04, forking libvirtd to the background confuses systemd, which loses track of the service. As the calling process terminates, systemd incorrectly believes the service is dead and flags it as error/inactive/dead.

This patch does not use the default "-d" flag on those systems.
