### PR TITLE
added option to change qemu-kvm package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,7 @@ class libvirt (
   $libvirt_package           = $::libvirt::params::libvirt_package,
   $libvirt_service           = $::libvirt::params::libvirt_service,
   $virtinst_package          = $::libvirt::params::virtinst_package,
+  $qemu_package              = $::libvirt::params::qemu_package,
   $radvd_package             = $::libvirt::params::radvd_package,
   $sysconfig                 = $::libvirt::params::sysconfig,
   $deb_default               = $::libvirt::params::deb_default,
@@ -120,7 +121,10 @@ class libvirt (
     package { $virtinst_package: ensure => installed }
   }
   if $qemu {
-    package { 'qemu-kvm': ensure => installed }
+    package { 'qemu-kvm':
+      ensure => installed,
+      name   => $qemu_package,
+    }
     file { '/etc/sasl2/qemu-kvm.conf':
       owner   => 'root',
       group   => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@ class libvirt::params {
       } else {
         $virtinst_package = 'python-virtinst'
       }
+      $qemu_package = 'qemu-kvm'
       $radvd_package = 'radvd'
       $sysconfig = {}
       $deb_default = false
@@ -20,6 +21,7 @@ class libvirt::params {
     'Debian': {
       $libvirt_package = 'libvirt-bin'
       $virtinst_package = 'virtinst'
+      $qemu_package = 'qemu-kvm'
       $radvd_package = 'radvd'
       $sysconfig = false
       $deb_default = {}
@@ -42,6 +44,7 @@ class libvirt::params {
       $libvirt_package = 'libvirt'
       $libvirt_service = 'libvirtd'
       $virtinst_package = 'python-virtinst'
+      $qemu_package = 'qemu-kvm'
       $radvd_package = 'radvd'
       $sysconfig = false
       $deb_default = false


### PR DESCRIPTION
The CentOS7 Virtualization SIG provides updated qemu-kvm packages, but they use a different package name (qemu-kvm-ev) which obsoletes and replaces the qemu-kvm package. Puppet can't detect that and tries to install qemu-kvm on every puppet run.
