### PR TITLE
Add space to the match so that we don't accidentally match network na…

### DIFF
--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -111,7 +111,7 @@ define libvirt::network (
       }
       exec { "virsh-net-define-${title}":
         command => "virsh net-define ${network_file}",
-        unless  => "virsh -q net-list --all | grep -Eq '^\s*${title}'",
+        unless  => "virsh -q net-list --all | grep -Eq '^\s*${title}\s'",
         require => Exec["create-${network_file}"],
       }
       if $autostart {


### PR DESCRIPTION
…mes that are substrings of other existing network names i.e. staging and staging2