### PR TITLE
Enable parameters for libvirtd.conf-el8.erb template

### DIFF
--- a/templates/libvirtd.conf-el8.erb
+++ b/templates/libvirtd.conf-el8.erb
@@ -19,7 +19,7 @@
 # using this capability.
 #
 # This is enabled by default, uncomment this to disable it
-#listen_tls = 0
+<% unless defined?(@listen_tls) %>#<% end %>listen_tls = <%= defined?(@listen_tls) && (@listen_tls ? '1' : '0') || '0' %>
 
 # Listen for unencrypted TCP connections on the public TCP/IP port.
 # NB, must pass the --listen flag to the libvirtd process for this to
@@ -30,19 +30,19 @@
 # DIGEST_MD5 and GSSAPI (Kerberos5)
 #
 # This is disabled by default, uncomment this to enable it.
-#listen_tcp = 1
+<% unless defined?(@listen_tcp) %>#<% end %>listen_tcp = <%= defined?(@listen_tcp) && (@listen_tcp ? '1' : '0') || '1' %>
 
 
 
 # Override the port for accepting secure TLS connections
 # This can be a port number, or service name
 #
-#tls_port = "16514"
+<% unless @tls_port %>#<% end %>tls_port = "<%= @tls_port || '16514' %>"
 
 # Override the port for accepting insecure TCP connections
 # This can be a port number, or service name
 #
-#tcp_port = "16509"
+<% unless @tcp_port %>#<% end %>tcp_port = "<%= @tcp_port || '16509' %>"
 
 
 # Override the default configuration which binds to all network
@@ -52,24 +52,7 @@
 # startup (e.g. with systemd), binding to addresses other than
 # the wildcards (0.0.0.0/::) might not be available yet.
 #
-#listen_addr = "192.168.0.1"
-
-
-# Flag toggling mDNS advertizement of the libvirt service.
-#
-# Alternatively can disable for all services on a host by
-# stopping the Avahi daemon
-#
-# This is disabled by default, uncomment this to enable it
-#mdns_adv = 1
-
-# Override the default mDNS advertizement name. This must be
-# unique on the immediate broadcast network.
-#
-# The default is "Virtualization Host HOSTNAME", where HOSTNAME
-# is substituted for the short hostname of the machine (without domain)
-#
-#mdns_name = "Virtualization Host Joe Demo"
+<% unless @listen_addr %>#<% end %>listen_addr = "<%= @listen_addr || '192.168.0.1' %>"
 
 
 #################################################################
@@ -82,14 +65,14 @@
 # without becoming root.
 #
 # This is restricted to 'root' by default.
-#unix_sock_group = "libvirt"
+<% unless @unix_sock_group %>#<% end %>unix_sock_group = "<%= @unix_sock_group || 'libvirt' %>"
 
 # Set the UNIX socket permissions for the R/O socket. This is used
 # for monitoring VM status only
 #
 # Default allows any user. If setting group ownership, you may want to
 # restrict this too.
-#unix_sock_ro_perms = "0777"
+<% unless @unix_sock_ro_perms %>#<% end %>unix_sock_ro_perms = "<%= @unix_sock_ro_perms || '0777' %>"
 
 # Set the UNIX socket permissions for the R/W socket. This is used
 # for full management of VMs
@@ -99,7 +82,7 @@
 #
 # If not using PolicyKit and setting group ownership for access
 # control, then you may want to relax this too.
-#unix_sock_rw_perms = "0770"
+<% unless @unix_sock_rw_perms %>#<% end %>unix_sock_rw_perms = "<%= @unix_sock_rw_perms || '0770' %>"
 
 # Set the UNIX socket permissions for the admin interface socket.
 #
@@ -108,7 +91,8 @@
 #unix_sock_admin_perms = "0700"
 
 # Set the name of the directory in which sockets will be found/created.
-#unix_sock_dir = "/var/run/libvirt"
+#
+<% unless @unix_sock_dir %>#<% end %>unix_sock_dir = "<%= @unix_sock_dir || '/run/libvirt' %>"
 
 
 
@@ -138,7 +122,7 @@
 #
 # To restrict monitoring of domains you may wish to enable
 # an authentication mechanism here
-#auth_unix_ro = "none"
+<% unless @auth_unix_ro %>#<% end %>auth_unix_ro = "<%= @auth_unix_ro || 'none' %>"
 
 # Set an authentication scheme for UNIX read-write sockets
 # By default socket permissions only allow root. If PolicyKit
@@ -147,7 +131,7 @@
 #
 # If the unix_sock_rw_perms are changed you may wish to enable
 # an authentication mechanism here
-#auth_unix_rw = "none"
+<% unless @auth_unix_rw %>#<% end %>auth_unix_rw = "<%= @auth_unix_rw || 'none' %>"
 
 # Change the authentication scheme for TCP sockets.
 #
@@ -155,7 +139,7 @@
 # Don't do this outside of a dev/test scenario. For real world
 # use, always enable SASL and use the GSSAPI or DIGEST-MD5
 # mechanism in /etc/sasl2/libvirt.conf
-#auth_tcp = "sasl"
+<% unless @auth_tcp %>#<% end %>auth_tcp = "<%= @auth_tcp || 'sasl' %>"
 
 # Change the authentication scheme for TLS sockets.
 #
@@ -164,7 +148,7 @@
 #
 # It is possible to make use of any SASL authentication
 # mechanism as well, by using 'sasl' for this option
-#auth_tls = "none"
+<% unless @auth_tls %>#<% end %>auth_tls = "<%= @auth_tls || 'none' %>"
 
 
 # Change the API access control scheme


### PR DESCRIPTION
mDNS was removed in livirt 5.5.0, so just remove that section.